### PR TITLE
Add test coverage percentage badge to README.md

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -4,6 +4,7 @@ source =
     overtime_calculator
 omit =
     overtime_calculator/setup.py
+    overtime_calculator/tests/*.py
 
 [report]
 fail_under = 80

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,5 @@ before_script:
 script:
   # Full test suite, incl. coverage
   - make test
+after_success:
+  - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,5 @@ before_script:
 script:
   # Full test suite, incl. coverage
   - make test
-after_success:
+after_script:
   - coveralls

--- a/Pipfile
+++ b/Pipfile
@@ -10,6 +10,7 @@ name = "pypi"
 hug = "*"
 hypothesis = "*"
 jwt = "*"
+coveralls = "*"
 
 
 [dev-packages]

--- a/Pipfile
+++ b/Pipfile
@@ -8,13 +8,13 @@ name = "pypi"
 [packages]
 
 hug = "*"
-hypothesis = "*"
 jwt = "*"
-coveralls = "*"
+hypothesis = "*"
 
 
 [dev-packages]
 
+coveralls = "*"
 ipython = "*"
 pytest = "*"
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Overtime-Calculator [![Build Status](https://travis-ci.org/x10an14/overtime-calculator.svg?branch=master)](https://travis-ci.org/x10an14/overtime-calculator)
+# Overtime-Calculator
+[![Build Status](https://travis-ci.org/x10an14/overtime-calculator.svg?branch=master)](https://travis-ci.org/x10an14/overtime-calculator)
+[![Coverage Status](https://coveralls.io/repos/github/x10an14/overtime-calculator/badge.svg?branch=ci-add-coveralls)](https://coveralls.io/github/x10an14/overtime-calculator?branch=ci-add-coveralls)
 Hobby programming project, with the intent of simplifying overtime calculation(s).
 
 ### Major dependencies:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Overtime-Calculator
 [![Build Status](https://travis-ci.org/x10an14/overtime-calculator.svg?branch=master)](https://travis-ci.org/x10an14/overtime-calculator)
 [![Coverage Status](https://coveralls.io/repos/github/x10an14/overtime-calculator/badge.svg?branch=ci-add-coveralls)](https://coveralls.io/github/x10an14/overtime-calculator?branch=ci-add-coveralls)
+
 Hobby programming project, with the intent of simplifying overtime calculation(s).
 
 ### Major dependencies:


### PR DESCRIPTION
So now we can see an actual percentage number when we test, as well as on Github! 

See [this line](https://github.com/x10an14/overtime-calculator/blob/8f052358031210b891234ce984850f0b9e1d1960/.coveragerc#L10) for where to specify the minimum coverage percentage =)